### PR TITLE
Made CDActivitySpinner ready to be used with Autolayout :)

### DIFF
--- a/Sources/CDActivitySpinner.m
+++ b/Sources/CDActivitySpinner.m
@@ -104,9 +104,9 @@
                                               self.frame.size.height / 2 - radius);
 }
 
-- (void) setFrame:(CGRect)frame
+- (void) layoutSubviews
 {
-    [super setFrame:frame];
+    [super layoutSubviews];
     [self adjustCircleToFrame];
 }
 


### PR DESCRIPTION
The setter for frame is not called when the view is being used with auto layout constraints. Using layoutSubviews however is called in all scenarios and the frames are updated after the constraints have been evaluated.